### PR TITLE
Ac 1970: Make pdt form safe for django 1.8

### DIFF
--- a/paypal/standard/pdt/forms.py
+++ b/paypal/standard/pdt/forms.py
@@ -7,3 +7,4 @@ from paypal.standard.pdt.models import PayPalPDT
 class PayPalPDTForm(PayPalStandardBaseForm):
     class Meta:
         model = PayPalPDT
+        fields = '__all__'

--- a/paypal/standard/pdt/forms.py
+++ b/paypal/standard/pdt/forms.py
@@ -8,3 +8,4 @@ class PayPalPDTForm(PayPalStandardBaseForm):
     class Meta:
         model = PayPalPDT
         fields = '__all__'
+


### PR DESCRIPTION
To test, specify branch=AC-1970 for django-python in base.cfg, and delete django-python from /src and /develop-eggs, then run ./update. 
